### PR TITLE
Process empty datasets

### DIFF
--- a/R/ofsaa.R
+++ b/R/ofsaa.R
@@ -25,7 +25,8 @@ ofsaa_data_object <- function(header, data, footer) {
   }
 
   serializeData <- function() {
-    column_order <- data %>% names() %>% extract(. != "REC_TYPE (=2)")
+    column_order <- data %>% names() %>% magrittr::extract(. != "REC_TYPE (=2)")
+
     readydata <-
       if(nrow(data) == 0) {
         data %>%

--- a/R/ofsaa.R
+++ b/R/ofsaa.R
@@ -25,11 +25,17 @@ ofsaa_data_object <- function(header, data, footer) {
   }
 
   serializeData <- function() {
-    column_order <- data %>% names()
-    readydata <- data %>%
-      magrittr::inset("REC_TYPE", value = 2) %>%
-      magrittr::inset("1", value = .$REC_TYPE) %>%
-      subset(select = c("1", column_order))
+    column_order <- data %>% names() %>% extract(. != "REC_TYPE (=2)")
+    readydata <-
+      if(nrow(data) == 0) {
+        data %>%
+          magrittr::inset("1", value = character()) %>%
+          subset(select = c("1", column_order))
+      } else {
+        data %>%
+          magrittr::inset("1", value = "2") %>%
+          subset(select = c("1", column_order))
+      }
 
     captured_output <- capture.output(
       write.table(
@@ -115,7 +121,11 @@ ofsaa_data <- function(dataframe, columns = NULL) {
 
       new_cols <- columns[!(columns %in% cols)]
       addColumn <- function(data, column) {
-        data[column] <- NA
+        if (nrow(data) == 0) {
+          data[column] <- character()
+        } else {
+          data[column] <- NA
+        }
         data
       }
       expanded <-


### PR DESCRIPTION
This PR resolves #1.

There is an error happens in attempt to save empty dataset. Error happens when data.frame is being extended with dummy "1" column with content "2".
In order to avoid this error control flow was added into column expansion function. For dataframes with zero rows (returned by `nrow` function) `character()` value is added for new columns. For dataframes with data in them `NA` value is added for new columns. 

Example:
```r
addColumn <- function(data, column) {
  if (nrow(data) == 0) {
    data[column] <- character()
  } else {
    data[column] <- NA
  }
  return(data)
}
```

Additionally error with column `REC_TYPE (=2)` has been fixed.